### PR TITLE
Fix chunked transfer replacement logic

### DIFF
--- a/replacements/scanFileAdvancedCall.new.java
+++ b/replacements/scanFileAdvancedCall.new.java
@@ -87,7 +87,7 @@ private ApiClient apiClient;
      * @throws ApiException If fail to serialize the request body object
      */
     public com.squareup.okhttp.Call scanFileAdvancedCall(java.io.InputStream inputFile, String fileName, Boolean allowExecutables, Boolean allowInvalidFiles, Boolean allowScripts, Boolean allowPasswordProtectedFiles, Boolean allowMacros, Boolean allowXmlExternalEntities, Boolean allowInsecureDeserialization, Boolean allowHtml, Boolean allowUnsafeArchives, Boolean allowOleEmbeddedObject, String options, String restrictFileTypes, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        Object localVarPostBody = null;
+        Object localVarPostBody = inputFile;
 
         // create path and map variables
         String localVarPath = "/virus/scan/file/advanced";
@@ -124,8 +124,6 @@ private ApiClient apiClient;
         localVarHeaderParams.put("restrictFileTypes", apiClient.parameterToString(restrictFileTypes));
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        if (inputFile != null)
-        localVarFormParams.put("inputFile", inputFile);
 
         final String[] localVarAccepts = {
             "application/json", "text/json", "application/xml", "text/xml"
@@ -134,7 +132,7 @@ private ApiClient apiClient;
         if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
 
         final String[] localVarContentTypes = {
-            "multipart/form-data"
+            "application/octet-stream"
         };
         final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
         localVarHeaderParams.put("Content-Type", localVarContentType);

--- a/src/main/java/com/cloudmersive/client/ScanApi.java
+++ b/src/main/java/com/cloudmersive/client/ScanApi.java
@@ -129,7 +129,7 @@ private ApiClient apiClient;
      * @throws ApiException If fail to serialize the request body object
      */
     public com.squareup.okhttp.Call scanFileAdvancedCall(java.io.InputStream inputFile, String fileName, Boolean allowExecutables, Boolean allowInvalidFiles, Boolean allowScripts, Boolean allowPasswordProtectedFiles, Boolean allowMacros, Boolean allowXmlExternalEntities, Boolean allowInsecureDeserialization, Boolean allowHtml, Boolean allowUnsafeArchives, Boolean allowOleEmbeddedObject, String options, String restrictFileTypes, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        Object localVarPostBody = null;
+        Object localVarPostBody = inputFile;
 
         // create path and map variables
         String localVarPath = "/virus/scan/file/advanced";
@@ -166,8 +166,6 @@ private ApiClient apiClient;
         localVarHeaderParams.put("restrictFileTypes", apiClient.parameterToString(restrictFileTypes));
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        if (inputFile != null)
-        localVarFormParams.put("inputFile", inputFile);
 
         final String[] localVarAccepts = {
             "application/json", "text/json", "application/xml", "text/xml"
@@ -176,7 +174,7 @@ private ApiClient apiClient;
         if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
 
         final String[] localVarContentTypes = {
-            "multipart/form-data"
+            "application/octet-stream"
         };
         final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
         localVarHeaderParams.put("Content-Type", localVarContentType);

--- a/src/main/java/com/cloudmersive/client/invoker/ApiClient.java
+++ b/src/main/java/com/cloudmersive/client/invoker/ApiClient.java
@@ -734,7 +734,10 @@ public class ApiClient {
      * @throws ApiException If fail to serialize the given object
      */
     public RequestBody serialize(Object obj, String contentType) throws ApiException {
-        if (obj instanceof byte[]) {
+        if (obj instanceof java.io.InputStream) {
+            // Stream body parameter support with chunked transfer encoding
+            return createRequestBodyFromInputStream(MediaType.parse(contentType), (java.io.InputStream) obj);
+        } else if (obj instanceof byte[]) {
             // Binary (byte array) body parameter support.
             return RequestBody.create(MediaType.parse(contentType), (byte[]) obj);
         } else if (obj instanceof File) {


### PR DESCRIPTION
## Summary
- update replacement snippet to send `InputStream` body directly
- keep ApiClient stream serialization logic

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683bac3046908328826a5ea30d988aa3