### PR TITLE
Fix chunked transfer post-generation

### DIFF
--- a/javaclientgen.ps1
+++ b/javaclientgen.ps1
@@ -62,6 +62,7 @@ function WhitespaceAgnosticReplace (
 
 
 WhitespaceAgnosticReplace './src/main/java/com/cloudmersive/client/invoker/ApiClient.java' './replacements/buildRequestBodyMultipart.old.java' './replacements/buildRequestBodyMultipart.new.java'
+WhitespaceAgnosticReplace './src/main/java/com/cloudmersive/client/invoker/ApiClient.java' './replacements/serialize.old.java' './replacements/serialize.new.java'
 
 WhitespaceAgnosticReplace './src/main/java/com/cloudmersive/client/ScanApi.java' './replacements/scanFileAdvancedCall.old.java' './replacements/scanFileAdvancedCall.new.java'
 

--- a/replacements/scanFileAdvancedCall.new.java
+++ b/replacements/scanFileAdvancedCall.new.java
@@ -87,7 +87,7 @@ private ApiClient apiClient;
      * @throws ApiException If fail to serialize the request body object
      */
     public com.squareup.okhttp.Call scanFileAdvancedCall(java.io.InputStream inputFile, String fileName, Boolean allowExecutables, Boolean allowInvalidFiles, Boolean allowScripts, Boolean allowPasswordProtectedFiles, Boolean allowMacros, Boolean allowXmlExternalEntities, Boolean allowInsecureDeserialization, Boolean allowHtml, Boolean allowUnsafeArchives, Boolean allowOleEmbeddedObject, String options, String restrictFileTypes, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        Object localVarPostBody = null;
+        Object localVarPostBody = inputFile;
 
         // create path and map variables
         String localVarPath = "/virus/scan/file/advanced";
@@ -124,8 +124,6 @@ private ApiClient apiClient;
         localVarHeaderParams.put("restrictFileTypes", apiClient.parameterToString(restrictFileTypes));
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-        if (inputFile != null)
-        localVarFormParams.put("inputFile", inputFile);
 
         final String[] localVarAccepts = {
             "application/json", "text/json", "application/xml", "text/xml"
@@ -134,7 +132,7 @@ private ApiClient apiClient;
         if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
 
         final String[] localVarContentTypes = {
-            "multipart/form-data"
+            "application/octet-stream"
         };
         final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
         localVarHeaderParams.put("Content-Type", localVarContentType);

--- a/replacements/serialize.new.java
+++ b/replacements/serialize.new.java
@@ -1,0 +1,23 @@
+    public RequestBody serialize(Object obj, String contentType) throws ApiException {
+        if (obj instanceof java.io.InputStream) {
+            // Stream body parameter support with chunked transfer encoding
+            return createRequestBodyFromInputStream(MediaType.parse(contentType), (java.io.InputStream) obj);
+        } else if (obj instanceof byte[]) {
+            // Binary (byte array) body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (byte[]) obj);
+        } else if (obj instanceof File) {
+            // File body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (File) obj);
+        } else if (isJsonMime(contentType)) {
+            String content;
+            if (obj != null) {
+                content = json.serialize(obj);
+            } else {
+                content = null;
+            }
+            return RequestBody.create(MediaType.parse(contentType), content);
+        } else {
+            throw new ApiException("Content type \"" + contentType + "\" is not supported");
+        }
+    }
+

--- a/replacements/serialize.old.java
+++ b/replacements/serialize.old.java
@@ -1,0 +1,19 @@
+    public RequestBody serialize(Object obj, String contentType) throws ApiException {
+        if (obj instanceof byte[]) {
+            // Binary (byte array) body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (byte[]) obj);
+        } else if (obj instanceof File) {
+            // File body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (File) obj);
+        } else if (isJsonMime(contentType)) {
+            String content;
+            if (obj != null) {
+                content = json.serialize(obj);
+            } else {
+                content = null;
+            }
+            return RequestBody.create(MediaType.parse(contentType), content);
+        } else {
+            throw new ApiException("Content type \"" + contentType + "\" is not supported");
+        }
+    }


### PR DESCRIPTION
## Summary
- revert direct modifications to generated files
- add InputStream serialization replacement
- update ScanApi replacement to send InputStreams
- wire new replacement into `javaclientgen.ps1`

## Testing
- `bash gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683bac3046908328826a5ea30d988aa3